### PR TITLE
Add queue id

### DIFF
--- a/example_config.toml
+++ b/example_config.toml
@@ -40,6 +40,7 @@ name="my radio"
 # codec: the audio codec to use (opus, vorbis, flac, do not specify for mp3 streams)
 # bitrate: the desired bitrate of the stream in Kb/s, if not specified an appropriate
 # bitrate will be automatically selected based on the container/codec
+[[streams]]
 mount="stream128.mp3"
 container="mp3"
 bitrate=128

--- a/src/api.rs
+++ b/src/api.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use serde_json as serde;
 use rouille;
 
-use queue::{Queue, QueueEntry};
+use queue::{Queue, NewQueueEntry};
 use config::ApiConfig;
 
 pub type Listeners = Arc<Mutex<HashMap<usize, Listener>>>;
@@ -29,7 +29,7 @@ pub enum QueuePos {
 pub enum ApiMessage {
     Skip,
     Remove(QueuePos),
-    Insert(QueuePos, QueueEntry),
+    Insert(QueuePos, NewQueueEntry),
     Clear,
 }
 
@@ -81,7 +81,7 @@ impl Server {
                 },
 
                 (POST) (/queue/head) => {
-                    match serde::from_reader(req.data().unwrap()).map(|d| QueueEntry::deserialize(d)) {
+                    match serde::from_reader(req.data().unwrap()).map(|d| NewQueueEntry::deserialize(d)) {
                         Ok(Some(qe)) => {
                             debug!("Handling queue head insert");
                             if Path::new(&qe.path).exists() {
@@ -121,7 +121,7 @@ impl Server {
 
                 (POST) (/queue/tail) => {
                     debug!("Handling queue tail insert");
-                    match serde::from_reader(req.data().unwrap()).map(|d| QueueEntry::deserialize(d)) {
+                    match serde::from_reader(req.data().unwrap()).map(|d| NewQueueEntry::deserialize(d)) {
                         Ok(Some(qe)) => {
                             debug!("Handling queue head insert");
                             if Path::new(&qe.path).exists() {


### PR DESCRIPTION
Upon adding a track to the queue, it will be augmented with a queue id.
This is meant to unambiguously identify an entry and should later be
used to e.g. specify which entry should be removed (instead of just
supporting 'head' and 'tail').

Completely untested as kawa exits right away without any error.