### PR TITLE
Added raw AAC/ADTS streaming support, and a few metadata headers

### DIFF
--- a/example_config.toml
+++ b/example_config.toml
@@ -36,8 +36,8 @@ name="my radio"
 # following properties are available:
 #
 # mount: the HTTP address to serve the stream from
-# container: the container format to use (ogg, flac, or mp3)
-# codec: the audio codec to use (opus, vorbis, flac, do not specify for mp3 streams)
+# container: the container format to use (ogg, flac, aac, or mp3)
+# codec: the audio codec to use (opus, vorbis, flac, aac, do not specify for mp3 streams)
 # bitrate: the desired bitrate of the stream in Kb/s, if not specified an appropriate
 # bitrate will be automatically selected based on the container/codec
 [[streams]]
@@ -49,6 +49,11 @@ bitrate=128
 mount="stream192.mp3"
 container="mp3"
 bitrate=192
+
+[[streams]]
+mount="stream128.aac"
+container="aac"
+bitrate=128
 
 [[streams]]
 mount="stream128.opus"

--- a/kaeru/src/lib.rs
+++ b/kaeru/src/lib.rs
@@ -252,6 +252,8 @@ impl GraphBuilder {
             if (*output.codec_ctx).codec_id == sys::AVCodecID::AV_CODEC_ID_OPUS {
                 // OPUS only supports 48kHz sample rates
                 (*output.codec_ctx).sample_rate = 48000;
+            } else if (*output.codec_ctx).codec_id == sys::AVCodecID::AV_CODEC_ID_AAC {
+                (*output.codec_ctx).sample_rate = 48000;
             } else if (*output.codec_ctx).codec_id == sys::AVCodecID::AV_CODEC_ID_MP3 {
                 // MP3 can't handle 192 kHz, so encode at 44.1
                 (*output.codec_ctx).sample_rate = 44100;
@@ -797,17 +799,20 @@ mod tests {
         let fout2 = File::create("test/test2.ogg").unwrap();
         let fout3 = File::create("test/test3.ogg").unwrap();
         let fout4 = File::create("test/test4.mp3").unwrap();
+        let fout5 = File::create("test/test5.aac").unwrap();
 
         let i = Input::new(fin, "mp3")?;
         let o1 = Output::new_writer(fout1, "ogg", super::AVCodecID::AV_CODEC_ID_OPUS, None)?;
         let o2 = Output::new_writer(fout2, "ogg", super::AVCodecID::AV_CODEC_ID_VORBIS, None)?;
         let o3 = Output::new_writer(fout3, "ogg", super::AVCodecID::AV_CODEC_ID_FLAC, None)?;
         let o4 = Output::new_writer(fout4, "mp3", super::AVCodecID::AV_CODEC_ID_MP3, None)?;
+        let o4 = Output::new_writer(fout5, "adts", super::AVCodecID::AV_CODEC_ID_AAC, None)?;
         let mut gb = GraphBuilder::new(i)?;
         gb.add_output(o1)?;
         gb.add_output(o2)?;
         gb.add_output(o3)?;
         gb.add_output(o4)?;
+        gb.add_output(o5)?;
         gb.build()?.run()
     }
 

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -398,6 +398,8 @@ impl Client {
                 "audio/mpeg"
             } else if let Container::FLAC = config.container {
                 "audio/flac"
+            } else if let Container::AAC = config.container {
+                "audio/aac"
             } else {
                 "audio/ogg"
             }),

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -396,13 +396,24 @@ impl Client {
             format!("Server: {}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")),
             format!("Content-Type: {}", if let Container::MP3 = config.container {
                 "audio/mpeg"
+            } else if let Container::FLAC = config.container {
+                "audio/flac"
             } else {
-                "application/ogg"
+                "audio/ogg"
             }),
             format!("Transfer-Encoding: chunked"),
             format!("Connection: keep-alive"),
             format!("Cache-Control: no-cache"),
             format!("x-audiocast-name: {}", name),
+            match config.bitrate {
+		Some(bitrate) => format!("x-audiocast-bitrate: {}", bitrate),
+		None => format!("x-audiocast-bitrate: 0"),
+	    },
+            format!("icy-name: {}", name),
+            match config.bitrate {
+                Some(bitrate) => format!("icy-br: {}", bitrate),
+                None => format!("icy-br: 0"),
+            },
         ];
         let data = lines.join("\r\n") + "\r\n\r\n";
         match self.conn.write(data.as_bytes()) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,7 @@ pub struct QueueConfig {
 pub enum Container {
     Ogg,
     MP3,
+    AAC,
     FLAC,
 }
 
@@ -84,8 +85,9 @@ impl InternalConfig {
             let container = match &*s.container {
                 "ogg" => Container::Ogg,
                 "mp3" => Container::MP3,
+                "aac" => Container::AAC,
                 "flac" => Container::FLAC,
-                _ => return Err(format!("Currently, only ogg, mp3, and flac are supported as containers.")),
+                _ => return Err(format!("Currently, only ogg, mp3, aac, and flac are supported as containers.")),
             };
             let codec = if let Some(c) = s.codec {
                 match &*c {
@@ -93,7 +95,8 @@ impl InternalConfig {
                     "vorbis" => AVCodecID::AV_CODEC_ID_VORBIS,
                     "flac" => AVCodecID::AV_CODEC_ID_FLAC,
                     "mp3" => AVCodecID::AV_CODEC_ID_MP3,
-                    _ => return Err(format!("Currently, only opus, vorbis, flac, and mp3 are \
+                    "aac" => AVCodecID::AV_CODEC_ID_AAC,
+                    _ => return Err(format!("Currently, only opus, vorbis, flac, aac, and mp3 are \
                                             supported as codecs.")),
                 }
             } else {
@@ -101,6 +104,7 @@ impl InternalConfig {
                 match container {
                     Container::Ogg => AVCodecID::AV_CODEC_ID_OPUS,
                     Container::MP3 => AVCodecID::AV_CODEC_ID_MP3,
+                    Container::AAC => AVCodecID::AV_CODEC_ID_AAC,
                     Container::FLAC => AVCodecID::AV_CODEC_ID_FLAC,
                 }
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,9 +115,10 @@ mod tests {
 
         let o1 = Output::new_writer(Dum(0), "mp3", kaeru::AVCodecID::AV_CODEC_ID_MP3, Some(192))?;
         let o2 = Output::new_writer(Dum(0), "ogg", kaeru::AVCodecID::AV_CODEC_ID_OPUS, Some(192))?;
-        let o3 = Output::new_writer(Dum(0), "ogg", kaeru::AVCodecID::AV_CODEC_ID_FLAC, None)?;
+        let o3 = Output::new_writer(Dum(0), "adts", kaeru::AVCodecID::AV_CODEC_ID_AAC, Some(192))?;
+        let o4 = Output::new_writer(Dum(0), "ogg", kaeru::AVCodecID::AV_CODEC_ID_FLAC, None)?;
         let mut gb = GraphBuilder::new(i)?;
-        gb.add_output(o1)?.add_output(o2)?.add_output(o3)?;
+        gb.add_output(o1)?.add_output(o2)?.add_output(o3)?.add_output(o4)?;
         let g = gb.build()?;
         let gt = thread::spawn(move || g.run().unwrap());
         gt.join();

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -197,6 +197,7 @@ impl Queue {
             let ct = match s.container {
                 Container::Ogg => "ogg",
                 Container::MP3 => "mp3",
+                Container::AAC => "adts",
                 Container::FLAC => "flac",
             };
             let output = kaeru::Output::new(tx, ct, s.codec, s.bitrate)?;


### PR DESCRIPTION
This adds raw AAC/ADTS streaming capabilities, adds the tests, and example config.

On top of these changes, i have added a small metadata addition that posts the bitrate on the `x-audiocast-*` header metadata, plus added similar `icy-*` headers.