### PR TITLE
Don't drop CString before returning pointer

### DIFF
--- a/kaeru/src/lib.rs
+++ b/kaeru/src/lib.rs
@@ -24,9 +24,10 @@ error_chain! {
 }
 
 macro_rules! str_conv {
-    ($s:expr) => {
-        CString::new($s).unwrap().as_ptr()
-    }
+    ($s:expr) => {{
+        let c_string = CString::new($s).unwrap();
+        c_string.as_ptr()
+    }}
 }
 
 macro_rules! ck_null {


### PR DESCRIPTION
It was UB before to do this: https://doc.rust-lang.org/std/ffi/struct.CString.html#method.as_ptr